### PR TITLE
Uncomment set-window-size-func. Seems to work perfectly fine

### DIFF
--- a/cepl.drm-gbm.lisp
+++ b/cepl.drm-gbm.lisp
@@ -198,4 +198,4 @@
 
 (set-step-func #'collect-drm-gbm-events)
 (set-swap-func #'drm-gbm-swap)
-;;(set-window-size-func #'drm-gbm-win-size)
+(set-window-size-func #'drm-gbm-win-size)


### PR DESCRIPTION
I managed to make ulubis get screen size from cepl[1]. This is the only change needed to other projects.

I wonder why was it commented-out in the first place?

[1] [changeset](https://github.com/Vespiary/ulubis/commit/6a82e372a8db58819b387fe22cf3d723306c6339). I'm going to do some more work on config user-friendliness in this branch.